### PR TITLE
fix: mounted error

### DIFF
--- a/lib/auth_states_supabase/auth_state_supabase.dart
+++ b/lib/auth_states_supabase/auth_state_supabase.dart
@@ -11,7 +11,9 @@ class AuthStateSupabase<T extends StatefulWidget> extends SupabaseAuthState<T> {
 
   @override
   void onAuthenticated(Session session) {
-    context.read<AppBloc>().add(const AppAuthenticated());
+    if (mounted) {
+      context.read<AppBloc>().add(const AppAuthenticated());
+    }
   }
 
 // coverage:ignore-start


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Sometimes when I started the app an error came up. The problem was that the widget was un-mounted and it couldn't access the context.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
